### PR TITLE
Refactored routes, added /timeout endpoint

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -13,9 +13,7 @@
   },
   "main": "index.ts",
   "dependencies": {
-    "body-parser": "1.19.0",
     "express": "4.17.1",
-    "http-status-codes": "1.4.0",
     "nodemon": "2.0.3"
   },
   "devDependencies": {},

--- a/js/src/config/routes.js
+++ b/js/src/config/routes.js
@@ -1,9 +1,0 @@
-const { Router } = require("express");
-const { PingController } = require("../controllers/ping_controller");
-
-module.exports = {
-    addRoutes: (expressApp) => {
-        const router = Router();
-        expressApp.use('/ping', router.get("/", PingController.ping))
-    }
-};

--- a/js/src/controllers/ping_controller.js
+++ b/js/src/controllers/ping_controller.js
@@ -1,5 +1,0 @@
-const { OK } = require("http-status-codes");
-
-module.exports.PingController = {
-    ping: (request, response) => response.status(OK).json("ping")
-};

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,13 +1,8 @@
-const express = require("express");
-const bodyParser = require("body-parser");
-const { addRoutes } = require("./config/routes");
+const express = require('express');
+const routes = require('./routes')
 
-const app = express();
 const port = process.env.PORT || 5000;
+const app = express();
+app.use(routes);
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
-addRoutes(app);
 app.listen(port, () => console.log(`Listening on port ${port}`));
-
-module.exports = app;

--- a/js/src/routes/index.js
+++ b/js/src/routes/index.js
@@ -1,0 +1,5 @@
+const PingRoute = require('./ping');
+const TimeoutRoute = require('./timeout');
+
+
+module.exports = [PingRoute, TimeoutRoute];

--- a/js/src/routes/ping.js
+++ b/js/src/routes/ping.js
@@ -1,0 +1,6 @@
+const { Router } = require('express');
+
+const router = Router();
+router.get('/ping', (req, res) => res.send('ping'));
+
+module.exports = router;

--- a/js/src/routes/timeout.js
+++ b/js/src/routes/timeout.js
@@ -1,0 +1,12 @@
+const { Router } = require('express')
+
+const SECOND = 1000;
+const DEFAULT_TIMEOUT = 5 * SECOND;
+
+const router = Router();
+router.get('/timeout', (req, res) => {
+    const time = (req.query.t && req.query.t * SECOND) || DEFAULT_TIMEOUT;
+    setTimeout(() => res.send(`node - timeout: ${time}`), time);
+})
+
+module.exports = router;

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -502,11 +502,6 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-status-codes@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
-  integrity sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
+ Added `GET /timeout` endpoint.
  + Optional `t` query param example: `/timeout?t=10` for **10** seconds.
Defaults to *5* if `t` is not provided.

+ Removed unnecesary dependencies `bodyParser` and `http-status-codes`

+ Refactored `routes`.